### PR TITLE
Update SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # cordova-plugin-usercentrics
 
-This plugin implements usercentrics features for cordova.
+This plugin implements UserCentrics SDK features for Cordova applications.
 
 ## how to install
 
-install it via cordova cli
+Install it via the Cordova CLI.
 
-```
+```sh
 cordova plugin add https://github.com/platogo/cordova-plugin-usercentrics.git
 ```
 
-**note:** curently supports android and ios only
+**note:** currently supports only Android
 
 ## usage
 
@@ -27,7 +27,7 @@ cordova.plugins.UserCentrics.initialize(
 );
 ```
 
-cause banner to show
+cause consent banner to show
 
 ```js
 cordova.plugins.UserCentrics.isReady(
@@ -52,19 +52,6 @@ cordova.plugins.UserCentrics.clearUserSession(
   }
 );
 
-```
-
-reset the sdk
-
-```js
-cordova.plugins.UserCentrics.sdkReset(
-  function (success) {
-    console.log(success);
-  },
-  function (error) {
-    console.error(error);
-  }
-);
 ```
 
 get google consents

--- a/src/android/UserCentrics.kt
+++ b/src/android/UserCentrics.kt
@@ -23,10 +23,6 @@ class UserCentrics :  CordovaPlugin() {
                 clearUserSession(callbackContext)
                 return true
             }
-            "sdkReset" -> {
-                sdkReset(callbackContext)
-                return true
-            }
             "getGoogleConsents" -> {
                 getGoogleConsents(callbackContext)
                 return true
@@ -104,16 +100,6 @@ class UserCentrics :  CordovaPlugin() {
         }, { error ->
             callbackContext.error(error.message)
         })
-    }
-
-
-    private fun sdkReset (callbackContext: CallbackContext){
-        try {
-            Usercentrics.reset()
-            callbackContext.success("sdk reset successfully")
-        } catch (e: Exception) {
-            callbackContext.error(e.message)
-        }
     }
 
     private fun getGoogleConsents (callbackContext: CallbackContext){

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0"
     }
 }
 
@@ -23,5 +23,5 @@ repositories {
 
 dependencies {
     // Usercentrics
-    implementation "com.usercentrics.sdk:usercentrics-ui:2.13.2"
+    implementation "com.usercentrics.sdk:usercentrics-ui:2.15.2"
 }


### PR DESCRIPTION
Ref: platogo/super-mobile-system#5453

- Bump SDK version to latest
- Remove deprecated `reset` method and references to it

We don't even use `reset` in the app other than for debugging.